### PR TITLE
📚 Add minimal Jekyll site for GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+theme: jekyll-theme-primer
+title: My Haskell Project

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+# My Haskell Project


### PR DESCRIPTION
## 📚 Add Minimal Jekyll Site for GitHub Pages

This PR introduces a minimal Jekyll setup to enable GitHub Pages support for this repository.

### Changes
- Created `docs/` directory with a simple `index.md`
- Added `_config.yml` with:
  - `jekyll-theme-primer` theme
  - Basic site title

### Purpose
This allows the project to be published as a documentation website via GitHub Pages, using the `docs/` folder as the source.

### Next Steps
- Expand `index.md` with useful documentation
- Add more pages or sections as the project evolves